### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   build-and-deploy:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
Potential fix for [https://github.com/owen-6936/Linkify/security/code-scanning/1](https://github.com/owen-6936/Linkify/security/code-scanning/1)

To fix the problem, add a `permissions` block to explicitly set the minimum required permissions for the job or workflow. For deploying with `peaceiris/actions-gh-pages@v3`, the workflow must be able to **push to the gh-pages branch**, which requires the `contents: write` permission (to push code), but does not require additional privileges. Therefore, add a `permissions: contents: write` block at the job level (i.e., under `build-and-deploy:`) for least privilege.

- Edit the `.github/workflows/deploy-pages.yml` file.
- Under the `build-and-deploy:` job (on line 11, before `runs-on`), insert a `permissions:` block defining `contents: write`.
- No new methods or external dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
